### PR TITLE
Bump httpx[http2] from 0.27.2 to 0.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ google-api-python-client
 gpytranslate
 gtts
 heroku3
-httpx[http2]==0.27.2
+httpx[http2]==0.28.1
 kurigram~=2.2.1
 lexica-api
 motor


### PR DESCRIPTION
Bumps [httpx[http2]](https://github.com/encode/httpx) from 0.27.2 to 0.28.1.
- [Release notes](https://github.com/encode/httpx/releases)
- [Changelog](https://github.com/encode/httpx/blob/master/CHANGELOG.md)
- [Commits](https://github.com/encode/httpx/compare/0.27.2...0.28.1)

---
updated-dependencies:
- dependency-name: httpx[http2] dependency-version: 0.28.1 dependency-type: direct:production update-type: version-update:semver-minor ...